### PR TITLE
Fixed CTtoSegmentation merge issue and fixed negative control settings

### DIFF
--- a/src/readii/metadata.py
+++ b/src/readii/metadata.py
@@ -73,7 +73,7 @@ def matchCTtoSegmentation(imgFileListPath: str,
     # Merge the CT and segmentation dataframes based on the CT ID (referenced in the segmentation rows)
     # Uses only segmentation keys, so no extra CTs are kept
     # If multiple CTs have the same ID, they are both included in this table
-    samplesWSeg = allCTRows.merge(allSegRows, how='right', 
+    samplesWSeg = allCTRows.merge(allSegRows, how='inner',
                                   left_on=['series', 'patient_ID'], 
                                   right_on=['reference_ct', 'patient_ID'], 
                                   suffixes=('_CT','_seg'))

--- a/src/readii/negative_controls.py
+++ b/src/readii/negative_controls.py
@@ -459,7 +459,7 @@ def applyNegativeControl(nc_type: str, baseImage: sitk.Image, baseROI: sitk.Imag
         return shuffleNonROI(baseImage, baseROI, roiLabel)
     elif nc_type == "randomized_sampled_full":
         # Make negative control version of ctImage (random sampled pixels from original distribution, same size)
-        return RandomizeImageFromDistribtutionSampling(baseImage)
+        return randomizeImageFromDistribtutionSampling(baseImage)
     elif nc_type == "randomized_sampled_roi":
         # Make negative control version of ctImage (random sampled pixels from original distribution inside ROI, same size)
         return makeRandomFromRoiDistribution(baseImage, baseROI, roiLabel)

--- a/src/readii/pipeline.py
+++ b/src/readii/pipeline.py
@@ -25,7 +25,7 @@ def parser():
     
     parser.add_argument("--negative_controls", type=str, default=None,
                         help="List of negative control types to run feature extraction on. Input as comma-separated list with no spaces.  \
-                              Options: randomized_full,randomized_roi,randomized_non_roi,shuffled_full,shuffled_roi,shuffled_non_roi")
+                              Options: randomized_full,randomized_roi,randomized_non_roi,shuffled_full,shuffled_roi,shuffled_non_roi,randomized_sampled_full,randomized_sampled_roi,randomized_sampled_non_roi")
 
     parser.add_argument("--parallel", action="store_true",
                         help="Whether to run feature extraction in a parallel process. False by default.")


### PR DESCRIPTION
1. Fixed the merge between the segmentations and the CT's from the medimagetools output, where right join on the segmentations dataframe was causing issues with non CT modalities
2. Fixed the issue with the naming of negative controls and added them to the -negative_control flag options list.