### PR TITLE
fix: Remove coloredlogs dependency and logging configuration from the project

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -464,23 +464,6 @@ files = [
 ]
 
 [[package]]
-name = "coloredlogs"
-version = "15.0.1"
-description = "Colored terminal output for Python's logging module"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934"},
-    {file = "coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0"},
-]
-
-[package.dependencies]
-humanfriendly = ">=9.1"
-
-[package.extras]
-cron = ["capturer (>=2.4)"]
-
-[[package]]
 name = "comm"
 version = "0.2.2"
 description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc."
@@ -1109,20 +1092,6 @@ brotli = ["brotli", "brotlicffi"]
 cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
-
-[[package]]
-name = "humanfriendly"
-version = "10.0"
-description = "Human friendly output for text interfaces using Python"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477"},
-    {file = "humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc"},
-]
-
-[package.dependencies]
-pyreadline3 = {version = "*", markers = "sys_platform == \"win32\" and python_version >= \"3.8\""}
 
 [[package]]
 name = "idna"
@@ -3006,17 +2975,6 @@ SimpleITK = ">=0.9.1"
 six = ">=1.10.0"
 
 [[package]]
-name = "pyreadline3"
-version = "3.4.1"
-description = "A python implementation of GNU readline."
-optional = false
-python-versions = "*"
-files = [
-    {file = "pyreadline3-3.4.1-py3-none-any.whl", hash = "sha256:b0efb6516fd4fb07b45949053826a62fa4cb353db5be2bbb4a7aa1fdd1e345fb"},
-    {file = "pyreadline3-3.4.1.tar.gz", hash = "sha256:6f3d1f7b8a31ba32b73917cefc1f28cc660562f39aea8646d30bd6eff21f7bae"},
-]
-
-[[package]]
 name = "pytest"
 version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
@@ -4614,4 +4572,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "930d1c6d45d391a3ed6bbdc5eb8a6e99d0f4d95df87372da9167da3b72cb056b"
+content-hash = "7e3c4a276ce999035dcc07f560b76f74a91d2f8f7194e082ace96e36313f13b4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dicom-parser = ">=1.2.3"
 matplotlib = ">=3.8.2"
 med-imagetools = "^1.2.0.2"
 pyarrow = "^15.0.0"
-coloredlogs = "^15.0.1"
 # pyradiomics = {git = "https://github.com/AIM-Harvard/pyradiomics.git"}
 pyradiomics = "3.0.1a3"
 

--- a/src/readii/utils/logging_config.py
+++ b/src/readii/utils/logging_config.py
@@ -13,7 +13,6 @@ BASE_LOGGING: dict = {
         #     'datefmt': '%Y-%m-%d %H:%M:%S',
         # },
         'stdout': {
-            'class': 'coloredlogs.ColoredFormatter',
             'format': '%(asctime)s %(levelname)s: %(message)s (%(module)s:%(funcName)s:%(lineno)d)',
             'datefmt': '%Y-%m-%d %H:%M:%S',
         },


### PR DESCRIPTION
Colored logs as logfiles is super messy. Removed for now for pipeline sake. 