### PR TITLE
feat: set StructureSetToSegmentation continuous argument to False

### DIFF
--- a/src/readii/loaders.py
+++ b/src/readii/loaders.py
@@ -72,7 +72,11 @@ def loadRTSTRUCTSITK(
 
 	# Set up segmentation loader
 	logger.debug(f"Making mask using ROI names: {roiNames}")
-	makeMask = StructureSetToSegmentation(roi_names=roiNames)
+	
+	# Initialize med-imagetools loader to convert RTSTRUCT point cloud to a segmentation
+	# Set continous to False to ensure indices are integers and not floats
+	makeMask = StructureSetToSegmentation(roi_names=roiNames,
+									      continuous=False)
 
 	try:
 		# Get the individual ROI masks


### PR DESCRIPTION
HNSCC data was generating the following error:
IndexError: [-65.00013333] index is out of bounds for image sized (123, 512, 512, 1).

This was caused by the med-imagetools class StructureSettoSegmentation initialization setting the continuous argument to True, which allowed for the RTSTRUCT physical points to be converted into indices that were floats instead of integers.

Setting continuous = False in loadRTSTRUCTSITK should solve this issue.